### PR TITLE
[#23] Reverting buttons and checkboxes

### DIFF
--- a/src/main/java/org/smilec/smile/bu/BoardManager.java
+++ b/src/main/java/org/smilec/smile/bu/BoardManager.java
@@ -47,7 +47,7 @@ import android.content.Context;
 public class BoardManager extends AbstractBaseManager {
 
     private static enum Type {
-        HAIL, QUESTION, QUESTION_PIC, ANSWER
+        HAIL, QUESTION, QUESTION_PIC, ANSWER, RE_TAKE
     }
 
     public Board getBoard(String ip, Context context) throws DataAccessException, NetworkErrorException {
@@ -141,6 +141,9 @@ public class BoardManager extends AbstractBaseManager {
                     case ANSWER:
                         jsonArrayAnswersAndRatings.add(object);
                         break;
+                    case RE_TAKE:
+                    	jsonArrayAnswersAndRatings = new ArrayList<JSONObject>();
+                    	break;
                 }
             } else {
                 // TODO Error

--- a/src/main/java/org/smilec/smile/bu/SmilePlugServerManager.java
+++ b/src/main/java/org/smilec/smile/bu/SmilePlugServerManager.java
@@ -286,9 +286,7 @@ public class SmilePlugServerManager extends AbstractBaseManager {
         } finally {
             IOUtil.silentClose(is);
         }
-
         return null;
-
     }
 
     public void startSolvingQuestions(String ip, Context context) throws NetworkErrorException {
@@ -310,7 +308,7 @@ public class SmilePlugServerManager extends AbstractBaseManager {
 				Question question = (Question) iterator.next();
 				answersList.add(question.getAnswer());
 			}
-			JSONArray answers = new JSONArray(answersList);		    
+			JSONArray answers = new JSONArray(answersList);
 			
 			post(ip, context, url, "{TYPE:'RE_TAKE',RANSWER:"+answers.toString()+",TIME_LIMIT:'"+10+"',NUMQ:'"+questionsNumber+"'}");
 			

--- a/src/main/java/org/smilec/smile/bu/json/AnswersAndRatingsJSONParser.java
+++ b/src/main/java/org/smilec/smile/bu/json/AnswersAndRatingsJSONParser.java
@@ -20,8 +20,10 @@ import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.smilec.smile.bu.Constants;
+import org.smilec.smile.domain.CurrentMessageStatus;
 import org.smilec.smile.domain.Question;
 import org.smilec.smile.domain.Student;
+import org.smilec.smile.ui.GeneralActivity;
 
 public class AnswersAndRatingsJSONParser {
 
@@ -34,10 +36,11 @@ public class AnswersAndRatingsJSONParser {
         String ip = object.optString(Constants.IP);
 
         Student student = students.get(ip);
-        if (student != null) {
-            student.setSolved(true);
-        }
 
+//        if (student != null) {
+//            student.setSolved(true);
+//        }
+        
         JSONArray answersArray = object.optJSONArray(ANSWERS);
         JSONArray ratingsArray = object.optJSONArray(RATINGS);
 
@@ -66,6 +69,13 @@ public class AnswersAndRatingsJSONParser {
                 question.addAnswer(answer);
                 student.addAnswer(question, answer);
 
+            }
+
+            // Retake scenario
+            if (!student.getAnswers().isEmpty()) {
+                student.setSolved(true);
+            } else {
+            	student.setSolved(false);
             }
         }
 

--- a/src/main/java/org/smilec/smile/ui/GeneralActivity.java
+++ b/src/main/java/org/smilec/smile/ui/GeneralActivity.java
@@ -255,6 +255,8 @@ public class GeneralActivity extends FragmentActivity {
         if(status.equals(CurrentMessageStatus.RE_TAKE.name())) {
         	
         	status = CurrentMessageStatus.START_MAKE.name();
+        	btSolve.setEnabled(true);
+        	btResults.setEnabled(false);
         }
         
         btSolve.setOnClickListener(new SolveButtonListener());


### PR DESCRIPTION
Relative issue: 
#23

https://github.com/RazortoothRTC/node-smile-server/issues/42

Reverting buttons to initial state, uncheck checkboxes of students, dropping ratings and answers
Retake button looks good on teacher app now.
I still need to update the variable `SMILESTATE` in **node-smile-server** >> **smilestudent.js** but I don't really know how this variable is updated from the server
