### PR TITLE
[#21] Teacher can see when a session is already running

### DIFF
--- a/res/drawable/button_grey.xml
+++ b/res/drawable/button_grey.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:state_pressed="true" >
+        <shape>
+            <gradient
+                android:startColor="@color/btn_grey_dark"
+                android:endColor="@color/btn_grey_light"
+                android:angle="270" />
+            <stroke
+                android:width="2dp"
+                android:color="@color/btn_grey_light" />
+            <corners
+                android:radius="3dp" />
+            <padding
+                android:left="10dp"
+                android:top="10dp"
+                android:right="10dp"
+                android:bottom="10dp" />
+        </shape>
+    </item><item>        
+        <shape>
+            <gradient
+                android:startColor="@color/btn_grey_light"
+                android:endColor="@color/btn_grey_dark"
+                android:angle="270" />
+            <stroke
+                android:width="2dp"
+                android:color="@color/btn_grey_dark" />
+            <corners
+                android:radius="3dp" />
+            <padding
+                android:left="10dp"
+                android:top="10dp"
+                android:right="10dp"
+                android:bottom="10dp" />
+        </shape>
+    </item>
+</selector>

--- a/res/drawable/button_orange.xml
+++ b/res/drawable/button_orange.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:state_pressed="true" >
+        <shape>
+            <gradient
+                android:startColor="@color/btn_orange_dark"
+                android:endColor="@color/btn_orange_light"
+                android:angle="270" />
+            <stroke
+                android:width="2dp"
+                android:color="@color/btn_orange_light" />
+            <corners
+                android:radius="3dp" />
+            <padding
+                android:left="10dp"
+                android:top="10dp"
+                android:right="10dp"
+                android:bottom="10dp" />
+        </shape>
+    </item><item>        
+        <shape>
+            <gradient
+                android:startColor="@color/btn_orange_light"
+                android:endColor="@color/btn_orange_dark"
+                android:angle="270" />
+            <stroke
+                android:width="2dp"
+                android:color="@color/btn_orange_dark" />
+            <corners
+                android:radius="3dp" />
+            <padding
+                android:left="10dp"
+                android:top="10dp"
+                android:right="10dp"
+                android:bottom="10dp" />
+        </shape>
+    </item>
+</selector>

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -17,6 +17,10 @@
     <color name="btn_green_dark">#47A447</color>
     <color name="btn_black_dark">#404040</color>
     <color name="btn_black_light">#9C9C9C</color>
+    <color name="btn_grey_dark">#CCCCCC</color>
+    <color name="btn_grey_light">#EEEEEE</color>
+    <color name="btn_orange_dark">#ED9A24</color>
+    <color name="btn_orange_light">#F0B665</color>
     <color name="btn_red_light">#D2322D</color>
     <color name="btn_red_dark">#D9534F</color>
     <color name="btn_yellow_light">#F8C606</color>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -15,7 +15,7 @@
 	
 	<!-- 	Toasts -->
 	<string name="toast_connection_established">Connection established</string>
-	<string name="toast_creating_session">Creating session…</string>
+	<string name="toast_creating_session">Preparing session…</string>
 	<string name="toast_starting">Starting…</string>
 	<string name="toast_solving">Solving…</string>
 	<string name="toast_sorting">Sorting…</string>
@@ -42,6 +42,7 @@
 	<string name="no_picture">No picture</string>
 	
 	<string name="start_making">Start Making Questions</string>
+	<string name="recovering_session">Recovering Session</string>
 	<string name="use_prepared">Use Prepared Questions</string>
 	<string name="start_solving">Start Solving \n Questions</string>
 	<string name="show_results">Finish:\nShow Results</string>

--- a/src/main/java/org/smilec/smile/bu/SmilePlugServerManager.java
+++ b/src/main/java/org/smilec/smile/bu/SmilePlugServerManager.java
@@ -165,6 +165,27 @@ public class SmilePlugServerManager extends AbstractBaseManager {
     }
     
     /**
+     * Ask to the server if a session is already running
+     */
+    public boolean isAlreadyRunningSession(String ip) throws NetworkErrorException {
+    	
+    	boolean bool = false;
+    	String url = SmilePlugUtil.createUrl(ip, SmilePlugUtil.ALL_DATA_URL);
+    	InputStream is = HttpUtil.executeGet(url);
+    	
+    	try {
+    		String smileAll = IOUtil.loadContent(is, "UTF-8");
+    		bool = smileAll.contains("SessionID");
+		} catch (IOException e) { 
+			e.printStackTrace();
+		} finally { 
+			IOUtil.silentClose(is);
+        }
+    			
+    	return bool;
+    }
+    
+    /**
      * Send the session metadata (teacher name, session name, and group name) to smileplug server
      */
     public void createSession(String ip, String teacherName, String sessionTitle, String groupName, Context context) throws NetworkErrorException {

--- a/src/main/java/org/smilec/smile/ui/ChooseActivityFlowDialog.java
+++ b/src/main/java/org/smilec/smile/ui/ChooseActivityFlowDialog.java
@@ -50,7 +50,9 @@ public class ChooseActivityFlowDialog extends Activity {
     private Button btExit;
 
     private Results results;
-
+    
+    private boolean alreadyRunning;
+    
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -64,6 +66,13 @@ public class ChooseActivityFlowDialog extends Activity {
         btExit = (Button) findViewById(R.id.bt_exit);
 
         status = this.getIntent().getStringExtra(GeneralActivity.PARAM_STATUS);
+        ip = this.getIntent().getStringExtra(GeneralActivity.PARAM_IP);
+        
+        try {
+			alreadyRunning = new SmilePlugServerManager().isAlreadyRunningSession(ip);
+		} catch (NetworkErrorException e) {
+			e.printStackTrace();
+		}
     }
 
     @Override
@@ -87,7 +96,18 @@ public class ChooseActivityFlowDialog extends Activity {
     protected void onResume() {
         super.onResume();
 
-        ip = this.getIntent().getStringExtra(GeneralActivity.PARAM_IP);
+        // If recovering...
+        if(alreadyRunning) {
+        	btUse.setEnabled(false);
+        	btUse.setBackgroundResource(R.drawable.button_grey);
+        	btStart.setBackgroundResource(R.drawable.button_orange);
+        	btStart.setText(R.string.recovering_session);
+        } else {
+        	btUse.setEnabled(true);
+        	btUse.setBackgroundResource(R.drawable.button_blue);
+        	btStart.setBackgroundResource(R.drawable.button_blue);
+        	btStart.setText(R.string.start_making);
+        }
         
         btStart.setOnClickListener(new StartButtonListener());
         btUse.setOnClickListener(new UsePreparedQuestionsButtonListener());

--- a/src/main/java/org/smilec/smile/ui/GeneralActivity.java
+++ b/src/main/java/org/smilec/smile/ui/GeneralActivity.java
@@ -169,14 +169,20 @@ public class GeneralActivity extends FragmentActivity {
         btResults.setEnabled(false);
         solve = true;
 
-        if (status != null) {
-            if (status.equals("") || !status.equals(CurrentMessageStatus.START_MAKE.name())) {
-                status = CurrentMessageStatus.START_MAKE.name();
-            }
-            tvStatus.setText(GAME_STATUS + CurrentMessageStatus.valueOf(status).getStatus());
-        } else {
-            new LoadStatusTask(this).execute();
+        if(status == null || status.equals("")) {
+        	status = CurrentMessageStatus.START_MAKE.name();
         }
+        
+        // TODO This code seems useless. Lets comment it to see what will happen
+        
+//        if (status != null) {
+//            if (!status.equals(CurrentMessageStatus.START_MAKE.name())) {
+//                status = CurrentMessageStatus.START_MAKE.name();
+//            }
+//            tvStatus.setText(GAME_STATUS + CurrentMessageStatus.valueOf(status).getStatus());
+//        } else {
+//            new LoadStatusTask(this).execute();
+//        }
 
     }
 

--- a/src/main/java/org/smilec/smile/ui/SessionValuesActivity.java
+++ b/src/main/java/org/smilec/smile/ui/SessionValuesActivity.java
@@ -127,8 +127,6 @@ public class SessionValuesActivity extends Activity {
         intent.putExtra(GeneralActivity.PARAM_IP, ip_smileplug);
         intent.putExtra(GeneralActivity.PARAM_STATUS, status);
         
-//        ActivityUtil.showLongToast(this, R.string.connection_established);
-        
         // Display toast through the handler
     	Message msg = null;
 		msg = mHandler.obtainMessage(MSG_OK, getResources().getString(R.string.toast_creating_session));
@@ -139,7 +137,6 @@ public class SessionValuesActivity extends Activity {
         
         // Closing SessionValuesActivity
         this.setVisible(false);
-//      this.finish();
     }
     
 	// To manage messages outside onCreate() method


### PR DESCRIPTION
Relative issue: #21
Instead of having a simple status displayed in _ChooseActivityFlowDialog_ layout, I strengthened a little bit this step by locking the "use prepared questions" button when a session is already running.
Here is a preview of the feature:
![screen shot 2014-04-08 at 22 38 32](https://cloud.githubusercontent.com/assets/3521208/2649078/bc483482-bf5e-11e3-8244-1e992680593b.png)
