### PR TITLE
[#23] Removing the cross in {Use prepared questions} layout when retaking

### DIFF
--- a/src/main/java/org/smilec/smile/ui/GeneralActivity.java
+++ b/src/main/java/org/smilec/smile/ui/GeneralActivity.java
@@ -414,9 +414,7 @@ public class GeneralActivity extends FragmentActivity {
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
     	
-    	/**
-    	 * TODO retake scenario (cf. issue #55)
-    	 * */
+    	// Adding Retake button to menu
     	if (btResults.isEnabled()) {
     		MenuItem item = menu.findItem(R.id.bt_retake);
     		if (item == null) {

--- a/src/main/java/org/smilec/smile/ui/UsePreparedQuestionsActivity.java
+++ b/src/main/java/org/smilec/smile/ui/UsePreparedQuestionsActivity.java
@@ -100,7 +100,7 @@ public class UsePreparedQuestionsActivity extends ListActivity {
         ip = this.getIntent().getStringExtra(GeneralActivity.PARAM_IP);
         results = (Results) this.getIntent().getSerializableExtra(GeneralActivity.PARAM_RESULTS);
         status = this.getIntent().getStringExtra(GeneralActivity.PARAM_STATUS);
-
+        
         btOk = (Button) findViewById(R.id.bt_ok);
         cbQuestions = (CheckBox) findViewById(R.id.cb_questions);
         spinnerHours = (Spinner) findViewById(R.id.sp_hours);
@@ -108,6 +108,11 @@ public class UsePreparedQuestionsActivity extends ListActivity {
         spinnerSeconds = (Spinner) findViewById(R.id.sp_seconds);
         btClose = (ImageButton) findViewById(R.id.bt_close);
 
+        // If retaking, we remove the cross
+        if(status.equals(CurrentMessageStatus.RE_TAKE.name())) {
+        	btClose.setVisibility(View.INVISIBLE);
+        }
+        
         lvListQuestions = getListView();
     }
 


### PR DESCRIPTION
Relative issue: #23
In a retake scenario, the cross appearing in `Use prepared questions` layout should not appear because at this moment, we are in the middle of a process. The teacher **already confirmed** previously he wanted to retake.
![screen shot 2014-04-11 at 18 33 03](https://cloud.githubusercontent.com/assets/3521208/2682176/15bcb954-c197-11e3-8a58-3ca57c880fdf.png)
![screen shot 2014-04-11 at 18 33 19](https://cloud.githubusercontent.com/assets/3521208/2682178/1928ab3e-c197-11e3-9764-fcd7400676f6.png)
