### PR TITLE
The login page redirects to the good page after synchronizing 

### DIFF
--- a/src/main/java/org/smilec/smile/bu/SmilePlugServerManager.java
+++ b/src/main/java/org/smilec/smile/bu/SmilePlugServerManager.java
@@ -49,6 +49,26 @@ import android.util.Log;
 import com.google.gson.Gson;
 
 public class SmilePlugServerManager extends AbstractBaseManager {
+	
+	/**
+     * Return <ip_server>/smile/all
+     */
+    public String getSmileAll(String ip) {
+    	
+    	
+    	String smileAll = new String();
+    	String url = SmilePlugUtil.createUrl(ip, SmilePlugUtil.ALL_DATA_URL);
+    	InputStream is = null;
+		
+    	try { is = HttpUtil.executeGet(url); } 
+		catch (NetworkErrorException e1) { e1.printStackTrace(); }
+    	
+    	try { smileAll = IOUtil.loadContent(is, "UTF-8"); } 
+    	catch (IOException e) { e.printStackTrace(); } 
+    	finally { IOUtil.silentClose(is); }
+    			
+    	return smileAll;
+    }
 
     public void startMakingQuestions(String ip, Context context) throws NetworkErrorException {
         

--- a/src/main/java/org/smilec/smile/ui/ChooseActivityFlowDialog.java
+++ b/src/main/java/org/smilec/smile/ui/ChooseActivityFlowDialog.java
@@ -125,13 +125,11 @@ public class ChooseActivityFlowDialog extends Activity {
         @Override
         public void onClick(View v) {
         	
+        	new LoadTask(ChooseActivityFlowDialog.this).execute();
+        	
             if (status != null && !status.equals("") && !status.equals("RESET")) {
-            	
-                new LoadTask(ChooseActivityFlowDialog.this).execute();
                 ActivityUtil.showLongToast(ChooseActivityFlowDialog.this, R.string.toast_recovering);
-
             } else {
-                new LoadTask(ChooseActivityFlowDialog.this).execute();
                 ActivityUtil.showLongToast(ChooseActivityFlowDialog.this, R.string.toast_starting);
             }
         }

--- a/src/main/java/org/smilec/smile/ui/LoginActivity.java
+++ b/src/main/java/org/smilec/smile/ui/LoginActivity.java
@@ -182,23 +182,33 @@ public class LoginActivity extends Activity {
         }
     }
 
-    private void loading() {
-        Intent intent = new Intent(this, SessionValuesActivity.class);
-        intent.putExtra(GeneralActivity.PARAM_IP, tvIp.getText().toString());
-        intent.putExtra(GeneralActivity.PARAM_STATUS, status);
-        //ActivityUtil.showLongToast(this, R.string.connection_established);
-        //this.setVisible(false);
-        
-        // Display toast through the handler
+    private void synchonizing() {
+    	
+    	String all = new SmilePlugServerManager().getSmileAll(tvIp.getText().toString());
+    	
+    	Intent intent = null;
+    	
+    	// Display toast through the handler
     	Message msg = null;
-		msg = mHandler.obtainMessage(MSG_OK, getResources().getString(R.string.toast_connection_established));
+    	msg = mHandler.obtainMessage(MSG_OK, getResources().getString(R.string.toast_connection_established));
 		mHandler.sendMessage(msg);
-		
-		//Starting SessionValuesActivity
-        startActivity(intent);
 
-        //Closing LoginActivity
-//        this.setVisible(false); 
+    	if(!all.contains("SESSION_VALUES")) {		
+    		intent = new Intent(this, SessionValuesActivity.class);
+    	} 
+    	else if(!all.contains("START_MAKE") && !all.contains("SessionID")) {
+    		intent = new Intent(this, ChooseActivityFlowDialog.class);
+    	} 
+    	else {
+    		intent = new Intent(this, GeneralActivity.class);
+            //intent.putExtra(GeneralActivity.PARAM_RESULTS, results);            
+    	}
+    	intent.putExtra(GeneralActivity.PARAM_IP, tvIp.getText().toString());
+        intent.putExtra(GeneralActivity.PARAM_STATUS, status);
+    	startActivity(intent);
+        // Closing LoginActivity
+        /* this.setVisible(false);
+    	  this.finish(); */
     }
     
 	// To manage messages outside onCreate() method
@@ -244,7 +254,7 @@ public class LoginActivity extends Activity {
             if (!message.equals("")) {
                 DialogUtil.checkConnection(LoginActivity.this, message);
             } else {
-                LoginActivity.this.loading();
+                LoginActivity.this.synchonizing();
             }
         }
     }


### PR DESCRIPTION
Relative issue: https://github.com/RazortoothRTC/node-smile-server/issues/39
The login page redirects to 'choose activity flow' or 'general activity' after synchronizing with the server
