### PR TITLE
[#42] Replacing "Recovering session" per "Recover session"

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -42,7 +42,7 @@
 	<string name="no_picture">No picture</string>
 
 	<string name="start_making">Start Making Questions</string>
-	<string name="recovering_session">Recovering Session</string>
+	<string name="recover_session">Recover Session</string>
 	<string name="use_prepared">Use Prepared Questions</string>
 	<string name="start_solving">Start Solving \n Questions</string>
 	<string name="show_results">Finish:\nShow Results</string>

--- a/src/main/java/org/smilec/smile/bu/json/IQSetJSONParser.java
+++ b/src/main/java/org/smilec/smile/bu/json/IQSetJSONParser.java
@@ -74,7 +74,7 @@ public class IQSetJSONParser {
     		
     		iqdata.put(new JSONObject()
 				.put(Constants.NAME, question.getOwner())
-				.put(Constants.IP,"127.0.0.1")
+				.put(Constants.IP,"No IP address")
 				.put(Constants.QUESTION, question.getQuestion())
 				.put(Constants.OPTION_1, question.getOption1())
 				.put(Constants.OPTION_2, question.getOption2())

--- a/src/main/java/org/smilec/smile/ui/ChooseActivityFlowDialog.java
+++ b/src/main/java/org/smilec/smile/ui/ChooseActivityFlowDialog.java
@@ -101,7 +101,7 @@ public class ChooseActivityFlowDialog extends Activity {
         	btUse.setEnabled(false);
         	btUse.setBackgroundResource(R.drawable.button_grey);
         	btStart.setBackgroundResource(R.drawable.button_orange);
-        	btStart.setText(R.string.recovering_session);
+        	btStart.setText(R.string.recover_session);
         } else {
         	btUse.setEnabled(true);
         	btUse.setBackgroundResource(R.drawable.button_blue);


### PR DESCRIPTION
Relative issue: #42
Replacing _"Recovering session"_ per _"Recover session"_
Replacing default value IP when saving an IQSet (_"No IP address"_ instead of _"127.0.0.1"_)
